### PR TITLE
fix: Allow Cordova plugin in Capacitor build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@outsystems/synapse",
-  "version": "1.0.0",
+  "name": "@capacitor/synapse",
+  "version": "1.0.2-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@outsystems/synapse",
-      "version": "1.0.0",
+      "name": "@capacitor/synapse",
+      "version": "1.0.2-dev.1",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/synapse",
-  "version": "1.0.1",
+  "version": "1.0.2-dev.1",
   "main": "./dist/synapse.cjs",
   "module": "./dist/synapse.mjs",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,11 @@ function createSynapseCordovaProxy(window: WindowObject): void {
 }
 
 /**
+ * Expose CapacitorUtils.Synapse.<pluginName>
+ * 
+ * By default it decides to use capacitor if is defined.
+ * If you want to instead use a cordova plugin in a capacitor shell, set overrideCapacitorWithCordova to true.
+ * 
  * Example use: 
  *    window.CapacitorUtils.Synapse.DemoPlugin.ping(
  *      {value: "hello"}, 
@@ -69,9 +74,9 @@ function createSynapseCordovaProxy(window: WindowObject): void {
  *      (err) => {console.error(err)}
  *    );
  */
-export function exposeSynapse(): void {
+export function exposeSynapse(overrideCapacitorWithCordova: boolean = false): void {
   (window as any).CapacitorUtils = (window as any).CapacitorUtils || {};
-  if ((window as any).Capacitor !== undefined) {
+  if ((window as any).Capacitor !== undefined && !overrideCapacitorWithCordova) {
     createSynapseCapacitorProxy(window as any);
   } else if ((window as any).cordova !== undefined) {
     createSynapseCordovaProxy(window as any);


### PR DESCRIPTION
## Description

Synapse assumes that if there's a Capacitor build, we want to use a Capacitor Plugin, and if there's a Cordova build, we want a Cordova Plugin.

However, the case for Capacitor compatibility with Cordova is also relevant: With a Capacitor build, use the Cordova Plugin - Provided that it works in a capacitor app, which must be guaranteed by the caller, not Synapse.

For this purpose, we added an optional `overrideCapacitorWithCordova` flag to `exposeSynapse` method.


## Context

https://outsystemsrd.atlassian.net/browse/RMET-4066